### PR TITLE
FIX : XDG : Use XDG_DATA_HOME when this is set

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -77,7 +77,7 @@ std::string elfeed_user_agent()
 
 std::string user_data_dir()
 {
-#if defined(__WXGTK__) || defined(__linux__) || defined(__FreeBSD__)
+    // Every platform: When XDG_DATA_HOME exists use that location
     // wxStandardPaths::SetFileLayout(FileLayout_XDG) *should* give
     // us $XDG_DATA_HOME/<app> on Linux, but on wxGTK 3.2 the layout
     // flip doesn't take effect for GetUserDataDir in practice and
@@ -87,19 +87,29 @@ std::string user_data_dir()
     //   1. $XDG_DATA_HOME/<app>
     //   2. $HOME/.local/share/<app>
     wxString base;
+#ifdef __WXMSW__
+    wxString win_appdata;
+#endif
     if (!wxGetEnv("XDG_DATA_HOME", &base) || base.empty()) {
         wxString home;
-        if (!wxGetEnv("HOME", &home) || home.empty())
+        if (!wxGetEnv("HOME", &home) || home.empty()) {
             home = wxGetHomeDir();
+#ifdef __WXMSW__
+            win_appdata = std_paths().GetUserDataDir();
+#endif
+        }
         base = home + "/.local/share";
     }
     wxString app = (wxTheApp && !wxTheApp->GetAppName().empty())
         ? wxTheApp->GetAppName()
         : wxString("elfeed2");
-    return (base + "/" + app).utf8_string();
-#else
-    return std_paths().GetUserDataDir().utf8_string();
+    base = base + "/" + app;
+#ifdef __WXMSW__
+    if (!win_appdata.empty()) {
+        base = win_appdata;
+    }
 #endif
+    return base.utf8_string();
 }
 
 std::string user_config_dir()


### PR DESCRIPTION
I've found a missing XDG functionality.

When the environment variable XDG_DATA_HOME is set on Windows this was not used.
The database was written to APPLOCAL, I've set the variables XDG_CONFIG_HOME and XDG_DATA_HOME.
XDG_CONFIG_HOME was used as expected, but XDG_DATA_HOME was not evaluated.

Therefore I've changed the routine `user_data_dir()` to evaluate XDG_DATA_HOME when it is present.
